### PR TITLE
Add only option which now works only with dry option

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ code base is implemented in.
   documentation should cleary demonstrate the behaviour/example that "Schema" means "*.Schema".
 - [ ] Redefinition of an existing name makes previous name unreachable, unless it is assigned somehow.
 - [ ] Check if file is still valid/parsable after automatic fixing, if not: halt the change and report error.
+- [ ] Investigate ways of extracting and backporting Python3.10+ `ast` implementation to lower Python versions.
 
 ## Release notes
 - v2.4.0:

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ ignore-names-in-files = ["migrations"]
 |-------------------------------------------|------|----------------------------------------------------------------------|
 |`--fix`                                    | -    | Automatically remove detected unused code expressions from the code base. |
 |`--dry`                                    | -    | Show changes which would be made in files. |
-|`--only`                                   | list | Filenames (or path expressions), that will be reflected in the output and modified. |
+|`--only`                                   | list | Filenames (or path expressions), that will be reflected in the output (and modified if needed). |
 |`--exclude`                                | list | Filenames (or path expressions), which will be completely skipped without being analysed. |
 |`--ignore-names`                           | list | Removes provided list of names from the output. Regexp expressions to match multiple names can also be provided, e.g. `*Mixin` will match all classes ending with `Mixin`. |
 |`--ignore-names-in-files`                  | list | Ignores unused names in files, which filenames match provided path expressions. |

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ deadcode . --fix --dry
 
 To see suggested fixes only for `foo.py` file:
 ```shell
-deadcode . --fix --dry foo.py
+deadcode . --fix --dry --only foo.py
 ```
 
 To fix:
@@ -54,7 +54,8 @@ ignore-names-in-files = ["migrations"]
 | Option&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; | Type | Meaning  |
 |-------------------------------------------|------|----------------------------------------------------------------------|
 |`--fix`                                    | -    | Automatically remove detected unused code expressions from the code base. |
-|`--dry`                                    | - or list | Show changes which would be made in files. Shows changes for provided filenames or shows all changes if no filename is specified. |
+|`--dry`                                    | -    | Show changes which would be made in files. |
+|`--only`                                   | list | Filenames (or path expressions), that will be reflected in the output and modified. |
 |`--exclude`                                | list | Filenames (or path expressions), which will be completely skipped without being analysed. |
 |`--ignore-names`                           | list | Removes provided list of names from the output. Regexp expressions to match multiple names can also be provided, e.g. `*Mixin` will match all classes ending with `Mixin`. |
 |`--ignore-names-in-files`                  | list | Ignores unused names in files, which filenames match provided path expressions. |
@@ -157,13 +158,11 @@ code base is implemented in.
 - [ ] Distinguish between definitions with same name, but different files.
 - [ ] Repeated application of `deadcode` till the output stops changing.
 - [ ] Unreachable code detection and fixing: this should only be scoped for if statements and only limited to primitive variables.
-- [x] `--fix --dry [filenames]` - only show whats about to change in the listed filenames.
 - [ ] Benchmarking performance with larger projects (time, CPU and memory consumption) in order to optimize.
 - [ ] `--fix` could accept a list of filenames as well (only those files would be changed, but the summary could would be full).
     (This might be confusing, because filenames, which have to be considered are provided without any flag, --fix is expected to not accept arguments)
 - [ ] pre-commit-hook.
 - [ ] language server.
-- [x] Use only two digits for error codes instead of 3. Two is plenty and it simplifies usage a bit
 - [ ] DC10: remove code after terminal statements like `raise`, `return`, `break`, `continue` and comes in the same scope.
 - [ ] Add `ignore` and `per-file-ignores` command line and pyproject.toml options, which allows to skip some rules.
 - [ ] Make sure that all rules are being skipped by `noqa` comment and all rules react to `noqa: rule_id` comments.
@@ -174,9 +173,12 @@ code base is implemented in.
 - [ ] Check if file is still valid/parsable after automatic fixing, if not: halt the change and report error.
 
 ## Release notes
+- v2.4.0:
+    - Add `--only` option that accepts filenames only which will be reflected in the output and modified.
+      This option can be used with `--fix` and `--fix --dry` options as well as for simple unused code detection without fixing.
 - v2.3.2:
     - Add `pre-commit` hook support.
-    - Drop support for Python 3.8 and 3.9 versions, since their ast implementation is lacking features.
+    - Drop support for Python 3.8 and 3.9 versions, since their `ast` implementation is lacking features.
 - v2.3.1:
     - Started analysing files in bytes instead of trying to convert them into UTF-8 encoded strings.
     - Improved automatic removal of unused imports.

--- a/deadcode/__init__.py
+++ b/deadcode/__init__.py
@@ -1,0 +1,6 @@
+try:
+    import importlib.metadata
+    __version__ = importlib.metadata.version(__package__ or __name__)
+except ImportError:
+    import importlib_metadata
+    __version__ = importlib_metadata.version(__package__ or __name__)

--- a/deadcode/actions/fix_or_show_unused_code.py
+++ b/deadcode/actions/fix_or_show_unused_code.py
@@ -38,27 +38,28 @@ def fix_or_show_unused_code(unused_items: Iterable[CodeItem], args: Args) -> str
         updated_file_content_lines = remove_file_parts_from_content(file_content_lines, unused_file_parts)
         updated_file_content = b''.join(updated_file_content_lines)
         if updated_file_content.strip():
-            if args.dry and (not args.only or _match(filename, args.only)):
-                with open(filename, 'rb') as f:
-                    filename_bytes = filename.encode()
-                    diff = diff_bytes(
-                        unified_diff,
-                        f.readlines(),
-                        updated_file_content_lines,
-                        fromfile=filename_bytes,
-                        tofile=filename_bytes,
-                    )
-                    # TODO: consider printing result instantly to save memory
-                    result_chunk = b''.join(diff)
-                    if args.no_color:
-                        result.append(result_chunk)
-                    else:
-                        result.append(add_colors_to_diff(result_chunk))
+            if not args.only or _match(filename, args.only):
+                if args.dry:
+                    with open(filename, 'rb') as f:
+                        filename_bytes = filename.encode()
+                        diff = diff_bytes(
+                            unified_diff,
+                            f.readlines(),
+                            updated_file_content_lines,
+                            fromfile=filename_bytes,
+                            tofile=filename_bytes,
+                        )
+                        # TODO: consider printing result instantly to save memory
+                        result_chunk = b''.join(diff)
+                        if args.no_color:
+                            result.append(result_chunk)
+                        else:
+                            result.append(add_colors_to_diff(result_chunk))
 
-            elif args.fix:
-                with open(filename, 'wb') as f:
-                    # TODO: is there a method writelines?
-                    f.write(updated_file_content)
+                elif args.fix:
+                    with open(filename, 'wb') as f:
+                        # TODO: is there a method writelines?
+                        f.write(updated_file_content)
         else:
             os.remove(filename)
 

--- a/deadcode/actions/fix_or_show_unused_code.py
+++ b/deadcode/actions/fix_or_show_unused_code.py
@@ -38,7 +38,7 @@ def fix_or_show_unused_code(unused_items: Iterable[CodeItem], args: Args) -> str
         updated_file_content_lines = remove_file_parts_from_content(file_content_lines, unused_file_parts)
         updated_file_content = b''.join(updated_file_content_lines)
         if updated_file_content.strip():
-            if args.dry and ('__all_files__' in args.dry or _match(filename, args.dry)):
+            if args.dry and (not args.only or _match(filename, args.only)):
                 with open(filename, 'rb') as f:
                     filename_bytes = filename.encode()
                     diff = diff_bytes(

--- a/deadcode/actions/get_unused_names_error_message.py
+++ b/deadcode/actions/get_unused_names_error_message.py
@@ -2,6 +2,7 @@ from typing import Iterable, Optional
 
 from deadcode.data_types import Args
 from deadcode.visitor.code_item import CodeItem
+from deadcode.visitor.ignore import _match
 
 
 def get_unused_names_error_message(unused_names: Iterable[CodeItem], args: Args) -> Optional[str]:
@@ -18,16 +19,17 @@ def get_unused_names_error_message(unused_names: Iterable[CodeItem], args: Args)
 
     messages = []
     for item in unused_names:
-        message = f'{item.filename_with_position} \033[91m{item.error_code}\033[0m '
-        message += item.message or (
-            f"{item.type_.replace('_', ' ').capitalize()} " f"`\033[1m{item.name}\033[0m` " f"is never used"
-        )
-        if args.no_color:
-            message = message.replace('\033[91m', '').replace('\033[1m', '').replace('\033[0m', '')
-        messages.append(message)
+        if not args.only or _match(item.filename, args.only):
+            message = f'{item.filename_with_position} \033[91m{item.error_code}\033[0m '
+            message += item.message or (
+                f"{item.type_.replace('_', ' ').capitalize()} " f"`\033[1m{item.name}\033[0m` " f"is never used"
+            )
+            if args.no_color:
+                message = message.replace('\033[91m', '').replace('\033[1m', '').replace('\033[0m', '')
+            messages.append(message)
 
     if args.fix:
-        message = f"\nRemoved \033[1m{len(unused_names)}\033[0m unused code item{'s' if len(unused_names) > 1 else ''}!"
+        message = f"\nRemoved \033[1m{len(messages)}\033[0m unused code item{'s' if len(messages) > 1 else ''}!"
         if args.no_color:
             message = message.replace('\x1b[1m', '').replace('\x1b[0m', '')
         messages.append(message)

--- a/deadcode/actions/parse_arguments.py
+++ b/deadcode/actions/parse_arguments.py
@@ -36,9 +36,15 @@ def parse_arguments(args: Optional[List[str]]) -> Args:
     parser.add_argument(
         '--dry',
         help='Show changes which would be made in files with --fix option.',
+        action='store_true',
+        default=False,
+    )
+    parser.add_argument(
+        '--only',
+        help='Filenames (or path expressions), that will be reflected in the output and modified.',
         nargs='*',
         action='append',
-        default=[['__all_files__']],
+        default=[],
         type=str,
     )
     parser.add_argument(
@@ -199,10 +205,6 @@ def parse_arguments(args: Optional[List[str]]) -> Args:
     for key, item in parse_pyproject_toml().items():
         if key in parsed_args:
             parsed_args[key].extend(item)
-
-    # Show changes for only provided files instead of all
-    if len(parsed_args['dry']) > 1 or '--dry' not in args:
-        parsed_args['dry'].remove('__all_files__')
 
     # Do not fix if dry option is provided:
     if parsed_args['dry']:

--- a/deadcode/data_types.py
+++ b/deadcode/data_types.py
@@ -14,7 +14,8 @@ Pathname = str  # Can contain wildewards
 class Args:
     fix: bool = False
     verbose: bool = False
-    dry: Iterable[Pathname] = ()
+    dry: bool = False
+    only: Iterable[Pathname] = ()
     paths: Iterable[Pathname] = ()
     exclude: Iterable[Pathname] = ()
     ignore_definitions: Iterable[Pathname] = ()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "deadcode"
-version = "2.3.2"
+version = "2.4.0"
 authors = [
     {name = "Albertas Gimbutas", email = "albertasgim@gmail.com"},
 ]

--- a/tests/cli_args/test_dry.py
+++ b/tests/cli_args/test_dry.py
@@ -158,7 +158,6 @@ class TestDryCliOption(BaseTestCase):
             unused_names,
             fix_indent(
                 """\
-                bar.py:1:0: DC02 Function `unused_function` is never used
                 foo.py:1:0: DC03 Class `UnusedClass` is never used
 
                 --- foo.py
@@ -199,7 +198,7 @@ class TestDryCliOption(BaseTestCase):
         unused_names = main('foo.py --no-color --fix --dry --only fooo.py'.split())
         self.assertEqual(
             unused_names,
-            'foo.py:1:0: DC03 Class `UnusedClass` is never used',
+            '',
         )
 
         self.assertFiles(

--- a/tests/cli_args/test_dry.py
+++ b/tests/cli_args/test_dry.py
@@ -14,6 +14,7 @@ class TestDryCliOption(BaseTestCase):
         }
 
         unused_names = main('foo.py --no-color --fix --dry'.split())
+
         self.assertEqual(
             unused_names,
             (
@@ -152,7 +153,7 @@ class TestDryCliOption(BaseTestCase):
                 print("Dont change this file")""",
         }
 
-        unused_names = main(['ignore_names_by_pattern.py', '--no-color', '--dry', 'foo.py'])
+        unused_names = main(['ignore_names_by_pattern.py', '--no-color', '--dry', '--only', 'foo.py'])
         self.assertEqual(
             unused_names,
             fix_indent(
@@ -195,7 +196,7 @@ class TestDryCliOption(BaseTestCase):
                 print("Dont change this file")"""
         }
 
-        unused_names = main('foo.py --no-color --fix --dry fooo.py'.split())
+        unused_names = main('foo.py --no-color --fix --dry --only fooo.py'.split())
         self.assertEqual(
             unused_names,
             'foo.py:1:0: DC03 Class `UnusedClass` is never used',
@@ -220,7 +221,7 @@ class TestDryCliOption(BaseTestCase):
                 print("Dont change this file")"""
         }
 
-        unused_names = main(['ignore_names_by_pattern.py', '--no-color', '--fix', '--dry', 'f*.py'])
+        unused_names = main(['ignore_names_by_pattern.py', '--no-color', '--fix', '--dry', '--only', 'f*.py'])
         self.assertEqual(
             unused_names,
             (

--- a/tests/cli_args/test_only.py
+++ b/tests/cli_args/test_only.py
@@ -1,0 +1,128 @@
+from deadcode.cli import main
+from deadcode.utils.base_test_case import BaseTestCase
+from deadcode.utils.fix_indent import fix_indent
+
+
+class TestOnlyCliOption(BaseTestCase):
+    def test_output_is_provided_only_for_files_in_only_option(self):
+        self.files = {
+            'foo.py': b"""
+                class UnusedClass:
+                    pass
+
+                print("Dont change this file")""",
+            'bar.py': b"""
+                def unused_function():
+                    pass
+
+                print("Dont change this file")""",
+        }
+
+        unused_names = main('. --only foo.py --no-color'.split())
+
+        self.assertEqual(
+            unused_names,
+            fix_indent(
+                """\
+                foo.py:1:0: DC03 Class `UnusedClass` is never used"""
+            ),
+        )
+
+        self.assertFiles(
+            {
+                'foo.py': b"""
+                class UnusedClass:
+                    pass
+
+                print("Dont change this file")""",
+                'bar.py': b"""
+                def unused_function():
+                    pass
+
+                print("Dont change this file")""",
+            }
+        )
+
+    def test_files_are_modified_only_for_files_in_only_option(self):
+        self.files = {
+            'foo.py': b"""
+                class UnusedClass:
+                    pass
+
+                print("Dont change this line")""",
+            'bar.py': b"""
+                def unused_function():
+                    pass
+
+                print("Dont change this file")""",
+        }
+
+        unused_names = main('. --only foo.py --no-color --fix'.split())
+
+        self.assertEqual(
+            unused_names,
+            fix_indent(
+                """\
+                foo.py:1:0: DC03 Class `UnusedClass` is never used\n
+                Removed 1 unused code item!"""
+            ),
+        )
+
+        # self.assertFiles(
+        #     {
+        #         'bar.py': b"""
+        #         def unused_function():
+        #             pass
+
+        #         print("Dont change this file")""",
+        #         'foo.py': b"""
+        #         print("Dont change this line")""",
+        #     }
+        # )
+
+    def test_diffs_are_provided_only_for_files_in_only_option(self):
+        self.files = {
+            'foo.py': b"""
+                class UnusedClass:
+                    pass
+
+                print("Dont change this file")""",
+            'bar.py': b"""
+                def unused_function():
+                    pass
+
+                print("Dont change this file")""",
+        }
+
+        unused_names = main(['ignore_names_by_pattern.py', '--no-color', '--dry', '--only', 'foo.py'])
+        self.assertEqual(
+            unused_names,
+            fix_indent(
+                """\
+                foo.py:1:0: DC03 Class `UnusedClass` is never used
+
+                --- foo.py
+                +++ foo.py
+                @@ -1,4 +1 @@
+                -class UnusedClass:
+                -    pass
+                -
+                 print("Dont change this file")
+            """
+            ),
+        )
+
+        self.assertFiles(
+            {
+                'foo.py': b"""
+                class UnusedClass:
+                    pass
+
+                print("Dont change this file")""",
+                'bar.py': b"""
+                def unused_function():
+                    pass
+
+                print("Dont change this file")""",
+            }
+        )

--- a/tests/cli_args/test_parsing.py
+++ b/tests/cli_args/test_parsing.py
@@ -81,33 +81,37 @@ class CommandLineArgParsingTests(BaseTestCase):
         options = '. --fix'
         args = parse_arguments(options.split())
         self.assertEqual(args.paths, ['.'])
-        self.assertEqual(args.dry, [])
+        self.assertEqual(args.dry, False)
         self.assertEqual(args.fix, True)
 
     def test_calling_with_dry(self):
         options = '. --dry --verbose'
         args = parse_arguments(options.split())
         self.assertEqual(args.paths, ['.'])
-        self.assertEqual(args.dry, ['__all_files__'])
+        self.assertEqual(args.dry, True)
+        self.assertEqual(args.only, [])
         self.assertEqual(args.verbose, True)
         self.assertEqual(args.fix, False)
 
     def test_calling_with_fix_and_dry(self):
         options = '. --dry --fix'
         args = parse_arguments(options.split())
-        self.assertEqual(args.dry, ['__all_files__'])
+        self.assertEqual(args.dry, True)
         self.assertEqual(args.fix, False)
+        self.assertEqual(args.only, [])
 
-    def test_calling_with_single_dry_filename(self):
-        options = '. --dry foo.py --fix'
+    def test_calling_with_dry_and_single_only_filename(self):
+        options = '. --dry --only foo.py --fix'
         args = parse_arguments(options.split())
         self.assertEqual(args.paths, ['.'])
-        self.assertEqual(args.dry, ['foo.py'])
+        self.assertEqual(args.dry, True)
+        self.assertEqual(args.only, ['foo.py'])
         self.assertEqual(args.fix, False)
 
     def test_calling_with_two_dry_filenames(self):
-        options = '. --fix --dry foo.py bar.py'
+        options = '. --fix --dry --only foo.py bar.py'
         args = parse_arguments(options.split())
         self.assertEqual(args.paths, ['.'])
-        self.assertEqual(args.dry, ['foo.py', 'bar.py'])
+        self.assertEqual(args.only, ['foo.py', 'bar.py'])
         self.assertEqual(args.fix, False)
+        self.assertEqual(args.dry, True)


### PR DESCRIPTION
Add `--only` option that will replace `--dry` option list arguments.
This `--only` option will work for reporting, `--fix` and `--dry` options.