### PR TITLE
Fix crash caused due to decorators not having id attribute

### DIFF
--- a/deadcode/visitor/utils.py
+++ b/deadcode/visitor/utils.py
@@ -58,7 +58,7 @@ def get_decorator_name(decorator: Union[ast.Call, ast.Attribute]) -> str:
     while isinstance(decorator, ast.Attribute):
         parts.append(decorator.attr)
         decorator = decorator.value  # type: ignore
-    parts.append(decorator.id)  # type: ignore
+        parts.append(str(id(decorator)))  # type: ignore
     return '@' + '.'.join(reversed(parts))
 
 

--- a/tests/visitor/test_utils.py
+++ b/tests/visitor/test_utils.py
@@ -1,0 +1,31 @@
+import ast
+import re
+
+from deadcode.visitor.utils import get_decorator_name
+
+class TestUtils:
+    def test_get_decorator_name_attribute(self):
+        # Test with a decorator with an attribute
+        decorator = ast.Attribute(value=ast.Name(id='module', ctx=ast.Load()), attr='my_decorator1')
+        assert get_decorator_name(decorator).endswith('.my_decorator1')
+
+        # Test with a complex decorator
+        decorator = ast.Attribute(
+            value=decorator,  # Create nested attributes
+            attr='my_decorator2',
+            ctx=ast.Load()
+        )
+        assert re.match(r'@\d+\.my_decorator1\.\d+\.my_decorator2', get_decorator_name(decorator))
+
+
+    def test_get_decorator_name_call(self):
+        decorator = ast.Attribute(value=ast.Name(id='module', ctx=ast.Load()), attr='my_decorator')
+        assert re.match(r'@\d+\.my_decorator', get_decorator_name(decorator))
+
+        # Test with a decorator that is a call
+        decorator = ast.Call(
+            func=decorator,
+            args=[],
+            keywords=[]
+        )
+        assert re.match(r'@\d+\.my_decorator', get_decorator_name(decorator))


### PR DESCRIPTION
This fixes the following error while running

```
  File "/home/thomas/.local/lib/python3.10/site-packages/deadcode/visitor/utils.py", line 61, in get_decorator_name
    parts.append(decorator.id)  # type: ignore
AttributeError: 'Lambda' object has no attribute 'id'
```

Fixes: #29 