### PR TITLE
Fix mypy

### DIFF
--- a/.github/workflows/check-deadcode-on-python310.yml
+++ b/.github/workflows/check-deadcode-on-python310.yml
@@ -3,11 +3,7 @@
 
 name: Checks deadcode package with Python3.10
 
-on:
-  push:
-    branches: [ "main" ]
-  pull_request:
-    branches: [ "main" ]
+on: [push, pull_request, workflow_dispatch]
 
 permissions:
   contents: read

--- a/deadcode/visitor/utils.py
+++ b/deadcode/visitor/utils.py
@@ -58,7 +58,7 @@ def get_decorator_name(decorator: Union[ast.Call, ast.Attribute]) -> str:
     while isinstance(decorator, ast.Attribute):
         parts.append(decorator.attr)
         decorator = decorator.value  # type: ignore
-        parts.append(str(id(decorator)))  # type: ignore
+        parts.append(str(id(decorator)))
     return '@' + '.'.join(reversed(parts))
 
 


### PR DESCRIPTION
CI has started failing:

```
.venv/bin/mypy deadcode
deadcode/visitor/utils.py:61: error: Unused "type: ignore" comment 
[unused-ignore]
            parts.append(str(id(decorator)))  # type: ignore
            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
Found 1 error in 1 file (checked 27 source files)
```

https://github.com/albertas/deadcode/actions/runs/17272794945/job/49021791684

